### PR TITLE
added syntax support for variables, locals, terraform blocks

### DIFF
--- a/Syntaxes/HCL.xml
+++ b/Syntaxes/HCL.xml
@@ -538,7 +538,7 @@
                     <context behavior="subtree" fold-type="function" />
                 </symbol>
                 <starts-with>
-                    <expression>(&lt;&lt;)(SHELL|BASH)</expression>
+                    <expression>(&lt;&lt;)([A-Z]+)</expression>
                     <capture number="0" name="hcl.operator.heredoc.start" />
                 </starts-with>
                 <ends-with>
@@ -552,7 +552,7 @@
             </scope>
             <scope name="hcl.block.heredoc.shell.indented">
                 <starts-with>
-                    <expression>(&lt;&lt;)-(SHELL|BASH)</expression>
+                    <expression>(&lt;&lt;)-([A-Z]+)</expression>
                     <capture number="0" name="hcl.operator.heredoc.start" />
                 </starts-with>
                 <ends-with>

--- a/Syntaxes/Terraform.xml
+++ b/Syntaxes/Terraform.xml
@@ -118,6 +118,43 @@
         
         <collection name="blocks">
         <!-- top-level resource -->
+            <scope name="terraform.locals.definition">
+                <symbol type="block">
+                    <context behavior="subtree" fold-type="function" />
+                </symbol>
+                <starts-with>
+                    <expression>(locals)\s+(\{)</expression>
+                    <capture number="1" name="terraform.keyword" />
+                </starts-with>
+                <ends-with>
+                    <expression>(\})</expression>
+                    <capture number="1" name="hcl.bracket.curly.close" />
+                </ends-with>
+                <subscopes>
+                    <include syntax="hcl" collection="assignments" />
+                </subscopes>
+            </scope>
+            <scope name="terraform.variable.definition">
+                <symbol type="block">
+                    <context behavior="subtree" fold-type="function" />
+                </symbol>
+                <starts-with>
+                    <expression>(variable)\s+("?[a-zA-Z][a-zA-Z0-9\_\-]*"?)\s+(\{)</expression>
+                    <capture number="1" name="terraform.keyword" />
+                    <capture number="2" name="terraform.identifier.type" />
+                    <capture number="3" name="hcl.bracket.curly.open" />
+                </starts-with>
+                <ends-with>
+                    <expression>(\})</expression>
+                    <capture number="1" name="hcl.bracket.curly.close" />
+                </ends-with>
+                <subscopes>
+                    <include syntax="hcl" collection="comments" />
+                    <include syntax="hcl" collection="assignments" />
+                    <include syntax="hcl" collection="inner-blocks" />
+                    <include syntax="hcl" collection="types" />
+                </subscopes>
+            </scope>
             <scope name="terraform.resource.definition">
                 <symbol type="block">"                    
                     <context behavior="subtree" fold-type="function" />
@@ -181,6 +218,28 @@
                 </ends-with>
                 <subscopes>
                     <include syntax="hcl" collection="comments" />
+                    <include syntax="hcl" collection="inner-blocks" />
+                    <include syntax="hcl" collection="strings" />
+                    <include syntax="hcl" collection="numbers" />
+                    <include syntax="hcl" collection="values" />
+                    <include syntax="hcl" collection="assignments" />
+                </subscopes>
+            </scope>
+            <scope name="terraform.block.terraform">
+                <symbol type="block">
+                    <context behavior="subtree" fold-type="function" />
+                </symbol>
+                <starts-with>
+                    <expression>(terraform)\s+(\{)</expression>
+                    <capture number="1" name="hcl.keyword" />
+                </starts-with>
+                <ends-with>
+                    <expression>(\})</expression>
+                    <capture number="1" name="hcl.bracket.curly.close" />
+                </ends-with>
+                <subscopes>
+                    <include syntax="hcl" collection="comments" />
+                    <include syntax="hcl" collection="inner-blocks" />
                     <include syntax="hcl" collection="strings" />
                     <include syntax="hcl" collection="numbers" />
                     <include syntax="hcl" collection="values" />


### PR DESCRIPTION
Thanks for the HCL syntax extension!  I noticed that variables, locals, and the root terraform block were not getting syntax highlighted, so I've added support for that.

Also, modified the HCL Heredoc support to accept any start/end tags, not just SHELL and BASH.